### PR TITLE
Fix PoW issues

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -100,12 +100,7 @@ public:
 
         convertSeed6(vFixedSeeds, pnSeed6_main, ARRAYLEN(pnSeed6_main));
 
-        if(nBestHeight < 392000)
-        { 
-        nLastPoWBlock = 380005;
-        } else { 
         nLastPoWBlock = 2147483645;
-        } 
 
         nTargetSpacing = 180; // Initially ~180 Sec during PoW
         if(nBestHeight > nLastPoWBlock) // Scaled down for PoS only phase

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -964,9 +964,9 @@ int64_t GetProofOfWorkReward(int64_t nHeight, int64_t nFees) {
 
     if(nHeight == 5) {
         nSubsidy = 2000000 * COIN;
-    } else if(nHeight > 5) {
-        nSubsidy = 100 * COIN;
-    }else if(nHeight > 387500) {
+    } else if(nHeight > 5 && nHeight < 392000) { // 1000 coins from block 6 through 391999
+        nSubsidy = 1000 * COIN;
+    } else if(nHeight >= 392000) { // 100.000 coins as of block 392000
         nSubsidy = 100000 * COIN;
     }
 


### PR DESCRIPTION
For the last PoW block: nBestHeight is always -1 when the constructor gets called. The if
statement is therefore pointless (because the else branch will
never be reached) and also technically wrong. It's best to remove
it altogether.

For the PoW reward: the last (newly added) else if is never reached because the first
else if condition evaluates to true.